### PR TITLE
Syntax error in settings.json

### DIFF
--- a/scaffold/.vscode/settings.json
+++ b/scaffold/.vscode/settings.json
@@ -5,7 +5,7 @@
     // they should only contain arguments and/or hxml files that are needed for completion,
     // such as -cp, -lib, target output settings and defines.
     "haxe.displayConfigurations": [
-        ["build.hxml"], // if a hxml file is safe to use, we can just pass it as argument
+        ["build.hxml"] // if a hxml file is safe to use, we can just pass it as argument
         // you can add more than one configuration and switch between them
         //["build-cpp.hxml"]
     ]


### PR DESCRIPTION
There's been an unnecessary comma in `scaffold/.vscode/settings.json`  😉 