### PR TITLE
Support for `export` API

### DIFF
--- a/vshaxe-build.json
+++ b/vshaxe-build.json
@@ -44,7 +44,7 @@
                 ],
                 "defines": [
                     "hxnodejs-no-version-warning",
-                    "JSTACK_MAIN=vshaxe.Main.main"
+                    "JSTACK_MAIN=vshaxe.Main.init"
                 ],
                 "output": {
                     "target": "js",


### PR DESCRIPTION
This adds (initial) support for an `export` API. This allows support for other Visual Studio Code extensions that need to work collaboratively with the VSHaxe extension.

 * Minor edits to make `activate` return an `export` object. This is the exported API, available to other Visual Studio Code extensions. The "jstack" library caused this message to behave asynchronously. Changes are made to allow this to return immediately.
 * The exported API currently includes two methods, an `onReady` `js.Promise` handler, and `updateDisplayArguments` to update the arguments used in the Haxe language server. `onReady` should work with multiple callbacks, and should return when (immediately or later) the Haxe language server is ready.

This is meant to take the first step in enabling an exported API from vshaxe, the above is enough to enable https://github.com/openfl/lime-vscode-extension

![screenshot from 2017-07-10 13-11-19](https://user-images.githubusercontent.com/833997/28037745-59e61fb8-6571-11e7-81a4-4b1abb24c97e.png)
