### PR TITLE
Initial DisplayArgumentProvider API

### DIFF
--- a/src/vshaxe/LanguageServer.hx
+++ b/src/vshaxe/LanguageServer.hx
@@ -10,11 +10,14 @@ class LanguageServer {
     var hxFileWatcher:FileSystemWatcher;
     var displayConfig:DisplayConfiguration;
     var dependencyExplorer:DependencyExplorer;
+    var onReadyCallback:Void->Void;
 
     public var client(default,null):LanguageClient;
+    public var isReady:Bool;
 
-    public function new(context:ExtensionContext) {
+    public function new(context:ExtensionContext, ?onReadyCallback:Void->Void) {
         this.context = context;
+        this.onReadyCallback = onReadyCallback;
 
         displayConfig = new DisplayConfiguration(context);
         dependencyExplorer = new DependencyExplorer(context, displayConfig.getConfiguration());
@@ -77,6 +80,11 @@ class LanguageServer {
                 commands.executeCommand("hxparservis.updateParseTree", result.uri, result.parseTree);
             });
             #end
+
+            isReady = true;
+            if (onReadyCallback != null) {
+                onReadyCallback();
+            }
         });
         disposable = client.start();
         context.subscriptions.push(disposable);
@@ -121,5 +129,19 @@ class LanguageServer {
         progresses = new Map();
 
         start();
+    }
+
+    public function updateDisplayArguments(arguments:String):Void {
+        // TODO: Better parsing
+        var args = [];
+        var lines = arguments.split("\n");
+        for (line in lines) {
+            line = StringTools.trim(line);
+            if (line != "") {
+                args = args.concat(line.split (" "));
+            }
+        }
+        client.sendNotification({method: "vshaxe/didChangeDisplayArguments"}, {arguments: args});
+        dependencyExplorer.onDidChangeDisplayArguments(args);
     }
 }

--- a/src/vshaxe/Main.hx
+++ b/src/vshaxe/Main.hx
@@ -1,12 +1,18 @@
 package vshaxe;
 
+import vshaxe.api.VshaxeAPI;
 import Vscode.*;
 import vscode.*;
 
 class Main {
+    public static var api:VshaxeAPI;
+    public static var instance:Main;
+
+    public var server:LanguageServer;
+
     function new(context:ExtensionContext) {
         new InitProject(context);
-        var server = new LanguageServer(context);
+        server = new LanguageServer(context, api.onReady);
         new Commands(context, server);
 
         setLanguageConfiguration();
@@ -22,6 +28,12 @@ class Main {
     @:keep
     @:expose("activate")
     static function main(context:ExtensionContext) {
-        new Main(context);
+        api = new VshaxeAPI();
+        init(context);
+        return api;
+    }
+
+    static function init(context:ExtensionContext) {
+        instance = new Main(context);
     }
 }

--- a/src/vshaxe/api/DisplayArgumentProvider.hx
+++ b/src/vshaxe/api/DisplayArgumentProvider.hx
@@ -1,0 +1,22 @@
+package vshaxe.api;
+
+typedef DisplayArgumentProvider = {
+
+    /**
+     * Called when vshaxe selects the provider for providing completion.
+     *
+     * @param provideArguments A callback that should be cached by the provider, and called whenever display arguments change.
+     *        The callback's `String` argument is assumed to be formatted like a HXML file and will be parsed by vshaxe.
+     *        `provideArguments` should only be called when necessary.
+     */
+    public function activate(provideArguments:String->Void):Void;
+
+    /**
+     * Called when this display argument provider is no longer active, for instance because the user has chosen to use
+     * another provider. The provider is informed about this to stop unnecessary system calls if deactivated.
+     *
+     * *Note:* a deactivated provider can be activated again!
+     */
+    public function deactivate():Void;
+
+}

--- a/src/vshaxe/api/VshaxeAPI.hx
+++ b/src/vshaxe/api/VshaxeAPI.hx
@@ -1,0 +1,59 @@
+package vshaxe.api;
+
+import Vscode.*;
+import vscode.*;
+
+@:allow(vshaxe)
+@:keep
+
+class VshaxeAPI {
+    private var currentDisposable:Disposable;
+    private var currentProvider:DisplayArgumentProvider;
+    private var displayArguments:String;
+    private var serverReady:Bool;
+
+    private function new() {
+
+    }
+
+    /**
+     * Register a display argument provider.
+     *
+     * Display arguments are passed to the Haxe Language Server for completion and used for the dependency explorer.
+     *
+     * An extension should only register a provider if it handles the current workspace's project type
+     * (usually when a matching project file is present, e.g. a `project.xml` in Lime's case).
+     * In the case of two competing providers, the user is prompted to select between them.
+     *
+     * @param name A unique ID to identify the extension. Shown to the user for conflict resolution.
+     * @param provider A display argument provider.
+     * @return A disposable which unregisters the provider.
+     */
+    public function registerDisplayArgumentProvider(name:String, provider:DisplayArgumentProvider):Disposable {
+        // TODO: Handle multiple providers
+        if (currentProvider == provider) return currentDisposable;
+        if (currentProvider != null && currentProvider != provider) {
+            currentProvider.deactivate();
+        }
+        currentProvider = provider;
+        provider.activate(updateDisplayArguments);
+        currentDisposable = new Disposable(function() {
+            if (provider == currentProvider) {
+                provider.deactivate();
+            }
+        });
+        return currentDisposable;
+    }
+
+    private function updateDisplayArguments(arguments:String):Void {
+        displayArguments = arguments;
+        if (serverReady && displayArguments != null) {
+            Main.instance.server.updateDisplayArguments(displayArguments);
+        }
+    }
+
+    private function onReady():Void {
+        serverReady = true;
+        updateDisplayArguments(displayArguments);
+    }
+}

--- a/vshaxe-build.json
+++ b/vshaxe-build.json
@@ -44,7 +44,7 @@
                 ],
                 "defines": [
                     "hxnodejs-no-version-warning",
-                    "JSTACK_MAIN=vshaxe.Main.main"
+                    "JSTACK_MAIN=vshaxe.Main.init"
                 ],
                 "output": {
                     "target": "js",


### PR DESCRIPTION
This adds (initial) support for an `DisplayArgumentProvider` API. This allows support for other Visual Studio Code extensions that need to work collaboratively with the VSHaxe extension.

 * Minor edits to make `activate` return an `export` object. This is the exported API, available to other Visual Studio Code extensions. The "jstack" library caused this message to behave asynchronously. Changes are made to allow this to return immediately.
 * The exported API currently includes one method, based on the feedback of @Gama11, in order to provide display arguments to vshaxe. Only one provider is currently supported in this implementation, but additional providers (with logic for which one to prefer) can be built out

This is meant to take the first step in enabling an exported API from vshaxe, the above is enough to enable https://github.com/openfl/lime-vscode-extension

![screenshot from 2017-07-10 13-11-19](https://user-images.githubusercontent.com/833997/28037745-59e61fb8-6571-11e7-81a4-4b1abb24c97e.png)
