### PR TITLE
Fixed isCommand logic

### DIFF
--- a/src/vshaxe/helper/HaxeExecutable.hx
+++ b/src/vshaxe/helper/HaxeExecutable.hx
@@ -113,7 +113,7 @@ class HaxeExecutable {
             if (FileSystem.exists(absolutePath)) {
                 executable = absolutePath;
             } else {
-                isCommand = false;
+                isCommand = true;
             }
         }
 


### PR DESCRIPTION
Hello,
Thanks for the recently added `isCommand` logic. The way I'd like to use it is:
`haxe.Executable: "bash.exe -c haxe"` which would allow me to install haxe only through the new "linux subsystem of windows. 
However, it looks like the `isCommand` is never put to `true`. 

Note: I have not tested this. I usually don't make PR of code that I didn't test, but I tried to build this extension in order to test the change and lost too much time on it by now. Please take a look and see if it is correct.

Cheers!
Pieter