### PR TITLE
Make sure that the Haxe absolute path is not a directory before setting it

### DIFF
--- a/src/vshaxe/helper/HaxeExecutable.hx
+++ b/src/vshaxe/helper/HaxeExecutable.hx
@@ -110,7 +110,7 @@ class HaxeExecutable {
         var isCommand = false;
         if (!Path.isAbsolute(executable)) {
             var absolutePath = PathHelper.absolutize(executable, workspace.rootPath);
-            if (FileSystem.exists(absolutePath)) {
+            if (FileSystem.exists(absolutePath) && !FileSystem.isDirectory(absolutePath)) {
                 executable = absolutePath;
             } else {
                 isCommand = true;


### PR DESCRIPTION
Otherwise, you cannot use vscode without specifying the absolute path to the haxe executable if there's a directory named `Haxe` on your project root