### PR TITLE
Improve indentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -740,6 +740,20 @@
 							]
 						}
 					}
+				},
+				"haxe.extendedIndentation": {
+					"type": "string",
+					"default": "dynamic",
+					"enum": [
+						"dynamic",
+						"k&r",
+						"allman"
+					],
+					"enumDescriptions": [
+						"Editor will align new line brackets with Allman style. Can have typing overhead.",
+						"One-line blocks without brackets have next level of indentation.",
+						"One-line blocks without brackets do not have level of indentation."
+					]
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -742,18 +742,9 @@
 					}
 				},
 				"haxe.extendedIndentation": {
-					"type": "string",
-					"default": "dynamic",
-					"enum": [
-						"dynamic",
-						"k&r",
-						"allman"
-					],
-					"enumDescriptions": [
-						"Editor will align new line brackets with Allman style. Can have typing overhead.",
-						"One-line blocks without brackets have next level of indentation.",
-						"One-line blocks without brackets do not have level of indentation."
-					]
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "Align new line brackets with Allman style. Can have typing overhead."
 				}
 			}
 		},

--- a/src/vshaxe/ExtendedIndentation.hx
+++ b/src/vshaxe/ExtendedIndentation.hx
@@ -1,5 +1,9 @@
 package vshaxe;
 
+private typedef TypeCommandArgs = {
+	text:String
+}
+
 class ExtendedIndentation {
 	final context:ExtensionContext;
 	var extendedIndentationDisposable:Null<Disposable>;
@@ -23,8 +27,9 @@ class ExtendedIndentation {
 		}
 	}
 
-	function extendedTyping(args) {
-		if (args.text == "{")
+	function extendedTyping(args:TypeCommandArgs) {
+		var editor = window.activeTextEditor;
+		if (editor != null && editor.document.languageId == "haxe" && args.text == "{")
 			indentCurlyBracket();
 		commands.executeCommand('default:type', args);
 	}

--- a/src/vshaxe/ExtendedIndentation.hx
+++ b/src/vshaxe/ExtendedIndentation.hx
@@ -1,0 +1,63 @@
+package vshaxe;
+
+class ExtendedIndentation {
+	final context:ExtensionContext;
+	var extendedIndentationDisposable:Null<Disposable>;
+	// With possible comments after bracket
+	final lineEndsWithOpenBracket = ~/[([{][\t ]*(\/\/.*|\/[*].*[*]\/[\t ]*)?$/;
+
+	public function new(context:ExtensionContext) {
+		this.context = context;
+		context.subscriptions.push(workspace.onDidChangeConfiguration(_ -> extendedIndentationToggle()));
+		extendedIndentationToggle();
+	}
+
+	function extendedIndentationToggle():Void {
+		var isActive = workspace.getConfiguration("haxe").get("extendedIndentation", false);
+		if (extendedIndentationDisposable != null)
+			extendedIndentationDisposable.dispose();
+
+		if (isActive) {
+			extendedIndentationDisposable = commands.registerCommand("type", extendedTyping);
+			context.subscriptions.push(extendedIndentationDisposable);
+		}
+	}
+
+	function extendedTyping(args) {
+		if (args.text == "{")
+			indentCurlyBracket();
+		commands.executeCommand('default:type', args);
+	}
+
+	function indentCurlyBracket():Void {
+		var editor = window.activeTextEditor;
+		if (editor == null)
+			return;
+		var lines:Array<{range:Range, spaces:String}> = [];
+		for (selection in editor.selections) {
+			if (!selection.isEmpty)
+				continue;
+			if (selection.active.line == 0)
+				continue;
+			var line = editor.document.lineAt(selection.active.line);
+			if (!line.isEmptyOrWhitespace)
+				continue;
+			var prevLine = editor.document.lineAt(selection.active.line - 1);
+			if (prevLine.text.length > 0) {
+				// Do not reindent if prev line has open bracket at the end
+				if (lineEndsWithOpenBracket.match(prevLine.text))
+					continue;
+			}
+			if (line.text.length < prevLine.firstNonWhitespaceCharacterIndex)
+				continue;
+			var spaces = prevLine.text.substr(0, prevLine.firstNonWhitespaceCharacterIndex);
+			lines.push({range: line.range, spaces: spaces});
+		}
+		if (lines.length == 0)
+			return;
+		editor.edit(edit -> {
+			for (line in lines)
+				edit.replace(line.range, line.spaces);
+		}, {undoStopBefore: false, undoStopAfter: false});
+	}
+}

--- a/src/vshaxe/HaxeCommand.hx
+++ b/src/vshaxe/HaxeCommand.hx
@@ -31,7 +31,6 @@ enum abstract HaxeCommand(String) to String {
 	var Cache_CopyNodeValue = command("cache.copyNodeValue");
 	var Cache_ReloadNode = command("cache.reloadNode");
 	var Cache_GotoNode = command("cache.gotoNode");
-	var Type = "type";
 
 	inline static function command(name:String):String {
 		return "haxe." + name;

--- a/src/vshaxe/HaxeCommand.hx
+++ b/src/vshaxe/HaxeCommand.hx
@@ -31,6 +31,7 @@ enum abstract HaxeCommand(String) to String {
 	var Cache_CopyNodeValue = command("cache.copyNodeValue");
 	var Cache_ReloadNode = command("cache.reloadNode");
 	var Cache_GotoNode = command("cache.gotoNode");
+	var Type = "type";
 
 	inline static function command(name:String):String {
 		return "haxe." + name;

--- a/src/vshaxe/Main.hx
+++ b/src/vshaxe/Main.hx
@@ -110,10 +110,7 @@ class Main {
 
 	function setLanguageConfiguration():Void {
 		// based on https://github.com/microsoft/vscode/blob/bb02817e2e549fd88710d0e0a0336b80648e90b5/extensions/typescript-language-features/src/features/languageConfiguration.ts#L15
-		var defaultWordPattern = "(-?\\d*\\.\\d\\w*)|([^\\`\\~\\!\\@\\#\\%\\^\\&\\*\\(\\)\\-\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\'\\\"\\,\\.\\<\\>\\/\\?\\s]+)";
-		var wordPattern = defaultWordPattern + "|(@:\\w*)"; // metadata
 		languages.setLanguageConfiguration("haxe", {
-			wordPattern: new RegExp(wordPattern),
 			indentationRules: {
 				decreaseIndentPattern: new RegExp("^((?!.*?\\/\\*).*\\*\\/)?\\s*[\\}\\]].*$"),
 				increaseIndentPattern: new RegExp("^((?!\\/\\/).)*(\\{[^}\"'`]*|\\([^)\"'`]*|\\[[^\\]\"'`]*)$"),
@@ -121,7 +118,7 @@ class Main {
 			},
 			onEnterRules: [
 				{
-					beforeText: new RegExp("^\\s*(\\bcase\\s.+:|\\bdefault:)$"),
+					beforeText: new RegExp("^\\s*(\\bcase\\s.+:|\\bdefault:)\\s*$"),
 					afterText: new RegExp("^(?!\\s*(\\bcase\\b|\\bdefault\\b))"),
 					action: {indentAction: vscode.IndentAction.Indent},
 				}

--- a/src/vshaxe/Main.hx
+++ b/src/vshaxe/Main.hx
@@ -65,6 +65,7 @@ class Main {
 		var taskConfiguration = new TaskConfiguration(haxeInstallation.haxe, problemMatchers, server, api);
 		new HxmlTaskProvider(taskConfiguration, hxmlDiscovery);
 		new HaxeTaskProvider(taskConfiguration, displayArguments, haxeDisplayArgumentsProvider);
+		setLanguageConfiguration();
 
 		scheduleServerStart(displayArguments, haxeInstallation, server);
 	}
@@ -79,7 +80,6 @@ class Main {
 		function maybeStartServer() {
 			if (!waitingForInstallation && !waitingForDisplayArguments && !serverStarted) {
 				disposables.iter(d -> d.dispose());
-				setLanguageConfiguration();
 				serverStarted = true;
 				server.start();
 			}
@@ -109,9 +109,6 @@ class Main {
 	}
 
 	function setLanguageConfiguration():Void {
-		var type:String = workspace.getConfiguration("haxe").get("extendedIndentation", "dynamic");
-		if (type == "allman")
-			return;
 		// based on https://github.com/microsoft/vscode/blob/bb02817e2e549fd88710d0e0a0336b80648e90b5/extensions/typescript-language-features/src/features/languageConfiguration.ts#L15
 		languages.setLanguageConfiguration("haxe", {
 			indentationRules: {

--- a/src/vshaxe/Main.hx
+++ b/src/vshaxe/Main.hx
@@ -1,5 +1,6 @@
 package vshaxe;
 
+import js.lib.RegExp;
 import vshaxe.commands.Commands;
 import vshaxe.commands.InitProject;
 import vshaxe.view.HaxeServerViewContainer;
@@ -64,6 +65,7 @@ class Main {
 		var taskConfiguration = new TaskConfiguration(haxeInstallation.haxe, problemMatchers, server, api);
 		new HxmlTaskProvider(taskConfiguration, hxmlDiscovery);
 		new HaxeTaskProvider(taskConfiguration, displayArguments, haxeDisplayArgumentsProvider);
+		setLanguageConfiguration();
 
 		scheduleServerStart(displayArguments, haxeInstallation, server);
 	}
@@ -104,6 +106,27 @@ class Main {
 
 		// or maybe we're just ready right away
 		maybeStartServer();
+	}
+
+	function setLanguageConfiguration():Void {
+		// based on https://github.com/microsoft/vscode/blob/bb02817e2e549fd88710d0e0a0336b80648e90b5/extensions/typescript-language-features/src/features/languageConfiguration.ts#L15
+		var defaultWordPattern = "(-?\\d*\\.\\d\\w*)|([^\\`\\~\\!\\@\\#\\%\\^\\&\\*\\(\\)\\-\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\'\\\"\\,\\.\\<\\>\\/\\?\\s]+)";
+		var wordPattern = defaultWordPattern + "|(@:\\w*)"; // metadata
+		languages.setLanguageConfiguration("haxe", {
+			wordPattern: new RegExp(wordPattern),
+			indentationRules: {
+				decreaseIndentPattern: new RegExp("^((?!.*?\\/\\*).*\\*\\/)?\\s*[\\}\\]].*$"),
+				increaseIndentPattern: new RegExp("^((?!\\/\\/).)*(\\{[^}\"'`]*|\\([^)\"'`]*|\\[[^\\]\"'`]*)$"),
+				indentNextLinePattern: new RegExp("(^\\s*(for|while|do|if|else|try|catch)|function)\\b(?!.*[;{}]\\s*(\\/\\/.*|\\/[*].*[*]\\/\\s*)?$)")
+			},
+			onEnterRules: [
+				{
+					beforeText: new RegExp("^\\s*(\\bcase\\s.+:|\\bdefault:)$"),
+					afterText: new RegExp("^(?!\\s*(\\bcase\\b|\\bdefault\\b))"),
+					action: {indentAction: vscode.IndentAction.Indent},
+				}
+			]
+		});
 	}
 
 	@:expose("activate")

--- a/src/vshaxe/Main.hx
+++ b/src/vshaxe/Main.hx
@@ -65,7 +65,6 @@ class Main {
 		var taskConfiguration = new TaskConfiguration(haxeInstallation.haxe, problemMatchers, server, api);
 		new HxmlTaskProvider(taskConfiguration, hxmlDiscovery);
 		new HaxeTaskProvider(taskConfiguration, displayArguments, haxeDisplayArgumentsProvider);
-		setLanguageConfiguration();
 
 		scheduleServerStart(displayArguments, haxeInstallation, server);
 	}
@@ -80,6 +79,7 @@ class Main {
 		function maybeStartServer() {
 			if (!waitingForInstallation && !waitingForDisplayArguments && !serverStarted) {
 				disposables.iter(d -> d.dispose());
+				setLanguageConfiguration();
 				serverStarted = true;
 				server.start();
 			}
@@ -109,6 +109,9 @@ class Main {
 	}
 
 	function setLanguageConfiguration():Void {
+		var type:String = workspace.getConfiguration("haxe").get("extendedIndentation", "dynamic");
+		if (type == "allman")
+			return;
 		// based on https://github.com/microsoft/vscode/blob/bb02817e2e549fd88710d0e0a0336b80648e90b5/extensions/typescript-language-features/src/features/languageConfiguration.ts#L15
 		languages.setLanguageConfiguration("haxe", {
 			indentationRules: {

--- a/src/vshaxe/commands/Commands.hx
+++ b/src/vshaxe/commands/Commands.hx
@@ -1,5 +1,6 @@
 package vshaxe.commands;
 
+import js.lib.RegExp;
 import vshaxe.display.HaxeDisplayArgumentsProvider;
 import vshaxe.server.LanguageServer;
 
@@ -79,6 +80,9 @@ class Commands {
 		commands.executeCommand('default:type', args);
 	}
 
+	// With possible comments after bracket
+	final lineEndsWithOpenBracket = new RegExp("[([{]\\s*(\\/\\/.*|\\/[*].*[*]\\/\\s*)?$");
+
 	function indentCurlyBracket():Void {
 		var editor = window.activeTextEditor;
 		if (editor == null)
@@ -94,8 +98,8 @@ class Commands {
 				continue;
 			var prevLine = editor.document.lineAt(selection.active.line - 1);
 			if (prevLine.text.length > 0) {
-				var char = prevLine.text.fastCodeAt(prevLine.text.length - 1);
-				if (char == "{".code || char == "[".code || char == "(".code)
+				// Do not reindent if prev line has open bracket at the end
+				if (lineEndsWithOpenBracket.test(prevLine.text))
 					continue;
 			}
 			if (line.text.length < prevLine.firstNonWhitespaceCharacterIndex)

--- a/src/vshaxe/commands/Commands.hx
+++ b/src/vshaxe/commands/Commands.hx
@@ -1,6 +1,5 @@
 package vshaxe.commands;
 
-import js.lib.RegExp;
 import vshaxe.display.HaxeDisplayArgumentsProvider;
 import vshaxe.server.LanguageServer;
 
@@ -84,7 +83,7 @@ class Commands {
 	}
 
 	// With possible comments after bracket
-	final lineEndsWithOpenBracket = new RegExp("[([{]\\s*(\\/\\/.*|\\/[*].*[*]\\/\\s*)?$");
+	final lineEndsWithOpenBracket = ~/[([{][\t ]*(\/\/.*|\/[*].*[*]\/[\t ]*)?$/;
 
 	function indentCurlyBracket():Void {
 		var editor = window.activeTextEditor;
@@ -102,7 +101,7 @@ class Commands {
 			var prevLine = editor.document.lineAt(selection.active.line - 1);
 			if (prevLine.text.length > 0) {
 				// Do not reindent if prev line has open bracket at the end
-				if (lineEndsWithOpenBracket.test(prevLine.text))
+				if (lineEndsWithOpenBracket.match(prevLine.text))
 					continue;
 			}
 			if (line.text.length < prevLine.firstNonWhitespaceCharacterIndex)

--- a/src/vshaxe/commands/Commands.hx
+++ b/src/vshaxe/commands/Commands.hx
@@ -19,7 +19,10 @@ class Commands {
 		context.registerHaxeCommand(RunGlobalDiagnostics, server.runGlobalDiagnostics);
 		context.registerHaxeCommand(ToggleCodeLens, toggleCodeLens);
 		context.registerHaxeCommand(DebugSelectedConfiguration, debugSelectedConfiguration);
-		context.registerHaxeCommand(Type, extendedTyping);
+
+		var type:String = workspace.getConfiguration("haxe").get("extendedIndentation", "dynamic");
+		if (type == "dynamic")
+			context.registerCommand("type", extendedTyping);
 
 		#if debug
 		context.registerHaxeCommand(ClearMementos, clearMementos);

--- a/src/vshaxe/helper/ContextHelper.hx
+++ b/src/vshaxe/helper/ContextHelper.hx
@@ -6,4 +6,8 @@ class ContextHelper {
 	public static function registerHaxeCommand(context:ExtensionContext, command:HaxeCommand, callback:Function) {
 		context.subscriptions.push(commands.registerCommand(command, callback));
 	}
+
+	public static function registerCommand(context:ExtensionContext, command:String, callback:Function) {
+		context.subscriptions.push(commands.registerCommand(command, callback));
+	}
 }


### PR DESCRIPTION
Closes #399, closes #133, examples:
```haxe
switch (true) {
	case true:|<Enter>
	case false:
}
if (true)
	false;|<Enter>
```
Not sure if i do this in right place, also these indentation rules need some time for testing.
`onEnterRules` for comments currently removed, not sure what doc style is default for Haxe and this probably needs style options.