### PR TITLE
Add changelog prompt

### DIFF
--- a/src/vshaxe/Main.hx
+++ b/src/vshaxe/Main.hx
@@ -67,6 +67,7 @@ function main(context:ExtensionContext) {
 	final haxeDisplayArgumentsProvider = new HaxeDisplayArgumentsProvider(context, displayArguments, hxmlDiscovery);
 	new Commands(context, server, haxeDisplayArgumentsProvider);
 	new ExtensionRecommender(context, folder).run();
+	new VshaxeChangelogPrompt(context);
 
 	final taskConfiguration = new TaskConfiguration(haxeInstallation, problemMatchers, server, api);
 	new HxmlTaskProvider(taskConfiguration, hxmlDiscovery);

--- a/src/vshaxe/VshaxeChangelogPrompt.hx
+++ b/src/vshaxe/VshaxeChangelogPrompt.hx
@@ -1,0 +1,35 @@
+package vshaxe;
+
+import haxe.Json;
+import haxe.io.Path;
+import sys.io.File;
+
+class VshaxeChangelogPrompt {
+	public function new(context:ExtensionContext) {
+		final memento = new HaxeMementoKey<String>("vshaxeVersion");
+		final globalState = context.globalState;
+		final version = readVersion() ?? return;
+		final lastSeenVersion = globalState.get(memento, "");
+		if (lastSeenVersion == version)
+			return;
+
+		final button = "Open Release Notes";
+		final prompt = window.showInformationMessage('VSHaxe has been updated to ${version}', button);
+		prompt.then(item -> {
+			if (item == button)
+				env.openExternal(Uri.parse("https://github.com/vshaxe/vshaxe/blob/master/CHANGELOG.md"));
+			globalState.update(memento, version);
+		});
+	}
+
+	function readVersion():Null<String> {
+		final ext = extensions.getExtension("nadako.vshaxe");
+		if (ext == null)
+			return null;
+		final extensionPath = ext.extensionPath;
+		if (extensionPath == null)
+			return null;
+		final path = Path.join([extensionPath, "package.json"]);
+		return Json.parse(File.getContent(path)).version;
+	}
+}

--- a/src/vshaxe/VshaxeChangelogPrompt.hx
+++ b/src/vshaxe/VshaxeChangelogPrompt.hx
@@ -8,7 +8,8 @@ class VshaxeChangelogPrompt {
 	public function new(context:ExtensionContext) {
 		final memento = new HaxeMementoKey<String>("vshaxeVersion");
 		final globalState = context.globalState;
-		final version = readVersion() ?? return;
+		final packageJson:{version:String} = context.extension.packageJSON;
+		final version = packageJson.version;
 		final lastSeenVersion = globalState.get(memento, "");
 		if (lastSeenVersion == version)
 			return;
@@ -20,16 +21,5 @@ class VshaxeChangelogPrompt {
 				env.openExternal(Uri.parse("https://github.com/vshaxe/vshaxe/blob/master/CHANGELOG.md"));
 			globalState.update(memento, version);
 		});
-	}
-
-	function readVersion():Null<String> {
-		final ext = extensions.getExtension("nadako.vshaxe");
-		if (ext == null)
-			return null;
-		final extensionPath = ext.extensionPath;
-		if (extensionPath == null)
-			return null;
-		final path = Path.join([extensionPath, "package.json"]);
-		return Json.parse(File.getContent(path)).version;
 	}
 }


### PR DESCRIPTION
Adds this message after any update:
<img width="470" alt="image" src="https://user-images.githubusercontent.com/8753432/170583587-67317eb4-6bcd-4d66-8a46-408369fb5081.png">
Would be nice to add `-D vshaxeVersion=...` to build tool, if its possible, so we dont need to read file here.