### PR TITLE
PathHelper.sanitizeComas added for findInFolder in DependecyTreeView

### DIFF
--- a/src/vshaxe/helper/PathHelper.hx
+++ b/src/vshaxe/helper/PathHelper.hx
@@ -46,4 +46,9 @@ class PathHelper {
 		}
 		return path;
 	}
+
+	public static function sanitizeComas(path:String) {
+		// https://github.com/microsoft/vscode/issues/70830
+		return path.split(",").join("[,]");
+	}
 }

--- a/src/vshaxe/view/dependencies/DependencyTreeView.hx
+++ b/src/vshaxe/view/dependencies/DependencyTreeView.hx
@@ -215,7 +215,7 @@ class DependencyTreeView {
 		}
 		commands.executeCommand("workbench.action.findInFiles", {
 			query: "",
-			filesToInclude: PathHelper.capitalizeDriveLetter(node.path)
+			filesToInclude: PathHelper.capitalizeDriveLetter(PathHelper.sanitizeComas(node.path))
 		});
 	}
 


### PR DESCRIPTION
Hej !

According to this issue https://github.com/microsoft/vscode/issues/70830, there is an issue when using FindInFolder VSCode command for example in a haxelib that has comas in its path.
The "solution" is to replace "," with "[,]".
I hope I've done that in a clean way and all is ok.