### PR TITLE
Add build/install info to README

### DIFF
--- a/Install.hx
+++ b/Install.hx
@@ -1,51 +1,49 @@
-import sys.io.File;
 import sys.FileSystem;
+import sys.io.File;
 
 using StringTools;
 
-class Install {
-	static function main() {
-		// this is not hacky at all... but seems there's no way to make `vsce package` skip prepublish
-		var restorePackageJson = tempModification("package.json", function(content) {
-			return content.split("\n").map(line -> if (line.contains("vscode:prepublish")) "" else line).join("\n");
-		});
-		var restoreVscodeIgnore = tempModification(".vscodeignore", function(content) {
-			return content + [
-				"vscode-languageclient",
-				"semver",
-				"vscode-languageserver-protocol",
-				"vscode-jsonrpc",
-				"vscode-languageserver-types",
-			].map(lib -> '!node_modules/$lib/**/*').join("\n");
-		});
-		function restore() {
-			restorePackageJson();
-			restoreVscodeIgnore();
-		}
-		try {
-			Sys.command("vsce package");
+function main() {
+	// this is not hacky at all... but seems there's no way to make `vsce package` skip prepublish
+	final restorePackageJson = tempModification("package.json", function(content) {
+		return content.split("\n").map(line -> if (line.contains("vscode:prepublish")) "" else line).join("\n");
+	});
+	final restoreVscodeIgnore = tempModification(".vscodeignore", function(content) {
+		return content + [
+			"vscode-languageclient",
+			"semver",
+			"vscode-languageserver-protocol",
+			"vscode-jsonrpc",
+			"vscode-languageserver-types",
+		].map(lib -> '!node_modules/$lib/**/*').join("\n");
+	});
+	function restore() {
+		restorePackageJson();
+		restoreVscodeIgnore();
+	}
+	try {
+		Sys.command("vsce package");
 
-			// if it didn't fail, there should be a .vsix now
-			var vsixFiles = FileSystem.readDirectory(".").filter(file -> file.endsWith(".vsix"));
-			if (vsixFiles.length > 1) {
-				Sys.println('Multiple vsix files found: $vsixFiles');
-			} else {
-				Sys.command('code --install-extension ${vsixFiles[0]}');
-				FileSystem.deleteFile(vsixFiles[0]);
-			}
-		} catch (e) {
-			trace(e);
-			restore();
+		// if it didn't fail, there should be a .vsix now
+		final vsixFiles = FileSystem.readDirectory(".").filter(file -> file.endsWith(".vsix"));
+		if (vsixFiles.length > 1) {
+			Sys.println('Multiple vsix files found: $vsixFiles');
+		} else {
+			Sys.command('code --install-extension ${vsixFiles[0]}');
+			FileSystem.deleteFile(vsixFiles[0]);
 		}
+	} catch (e) {
+		trace(e);
 		restore();
 	}
+	restore();
+}
 
-	static function tempModification(file:String, modify:(content:String) -> String):() -> Void {
-		var originalContent = File.getContent(file);
-		var newContent = modify(originalContent);
-		File.saveContent(file, newContent);
-		return function() {
-			File.saveContent(file, originalContent);
-		};
-	}
+function tempModification(file:String, modify:(content:String) -> String):() -> Void {
+	final originalContent = File.getContent(file);
+	final newContent = modify(originalContent);
+	File.saveContent(file, newContent);
+	return function() {
+		File.saveContent(file, originalContent);
+	};
 }

--- a/Install.hx
+++ b/Install.hx
@@ -22,7 +22,10 @@ function main() {
 		restoreVscodeIgnore();
 	}
 	try {
-		Sys.command("vsce package");
+		final out = Sys.command("vsce package");
+		if (out != 0) {
+			throw "Error: Failed to generate vsix file";
+		}
 
 		// if it didn't fail, there should be a .vsix now
 		final vsixFiles = FileSystem.readDirectory(".").filter(file -> file.endsWith(".vsix"));

--- a/README.md
+++ b/README.md
@@ -44,3 +44,29 @@ This is just a brief overview of the supported features. [**For more details, ch
 - [Code Lens](https://github.com/vshaxe/vshaxe/wiki/Code-Lens) (<kbd>F1</kbd> -> [Haxe: Toggle Code Lens](https://github.com/vshaxe/vshaxe/wiki/Commands#haxe-toggle-code-lens))
 - [Formatting](https://github.com/vshaxe/vshaxe/wiki/Formatting) (<kbd>Shift</kbd>+<kbd>Alt</kbd>+<kbd>F</kbd>)
 - [Extension API](https://github.com/vshaxe/vshaxe/wiki/Extension-API)
+
+## Development
+
+To work on this project locally, you must first install all the npm/lix dependencies:
+
+```sh
+npm install
+```
+
+You also must have [VSCode](https://code.visualstudio.com) and [vsce](https://github.com/microsoft/vscode-vsce#usage) installed and available in PATH.
+
+You can then build the extension using:
+
+```sh
+npx lix run vshaxe-build -t vshaxe
+```
+
+And then package and install the extension via:
+
+```sh
+npx lix Install
+```
+
+### Building in VSCode
+
+To work on `vshaxe` within VSCode, it is recommended to use the [vsbuild-haxe](https://github.com/vshaxe/vshaxe-build) extension, which integrates the build system used by `vshaxe` with VSCode. See the dedicated repository for detailed [installation instructions](https://github.com/vshaxe/vshaxe-build#building).

--- a/README.md
+++ b/README.md
@@ -45,28 +45,6 @@ This is just a brief overview of the supported features. [**For more details, ch
 - [Formatting](https://github.com/vshaxe/vshaxe/wiki/Formatting) (<kbd>Shift</kbd>+<kbd>Alt</kbd>+<kbd>F</kbd>)
 - [Extension API](https://github.com/vshaxe/vshaxe/wiki/Extension-API)
 
-## Development
+## Building
 
-To work on this project locally, you must first install all the npm/lix dependencies:
-
-```sh
-npm install
-```
-
-You also must have [VSCode](https://code.visualstudio.com) and [vsce](https://github.com/microsoft/vscode-vsce#usage) installed and available in PATH.
-
-You can then build the extension using:
-
-```sh
-npx lix run vshaxe-build -t vshaxe
-```
-
-And then package and install the extension via:
-
-```sh
-npx lix Install
-```
-
-### Building in VSCode
-
-To work on `vshaxe` within VSCode, it is recommended to use the [vsbuild-haxe](https://github.com/vshaxe/vshaxe-build) extension, which integrates the build system used by `vshaxe` with VSCode. See the dedicated repository for detailed [installation instructions](https://github.com/vshaxe/vshaxe-build#building).
+For instructions on building/installing from source, please see the dedicated [wiki page.](https://github.com/vshaxe/vshaxe/wiki/Installation)


### PR DESCRIPTION
Cleans up install script and documents how to use all the build/install commands.

For installation, there is also an `install` target provided via vshaxe-build, but that results in a longer command:
```sh
npx lix run vshaxe-build -t install
```
Compared to:
```sh
npx lix Install
```