### PR TITLE
Automatic selection of Haxe configuration based on file name

### DIFF
--- a/package.json
+++ b/package.json
@@ -349,6 +349,13 @@
 										"items": {
 											"type": "string"
 										}
+									},
+									"files": {
+										"type": "array",
+										"markdownDescription": "Array of files/globbing patterns where the editor should automatically select this configuration.",
+										"items": {
+											"type": "string"
+										}
 									}
 								}
 							}

--- a/src/vshaxe/display/HaxeDisplayArgumentsProvider.hx
+++ b/src/vshaxe/display/HaxeDisplayArgumentsProvider.hx
@@ -221,8 +221,8 @@ class HaxeDisplayArgumentsProvider {
 			var config = configurations.next();
 			switch config.kind {
 				case Configured(idx, _, files) if (files != null):
-					matchFileWithPatterns(files.iterator(), documentFsPath).then((v) -> {
-						if (v) {
+					matchFileWithPatterns(files.iterator(), documentFsPath).then((didMatch) -> {
+						if (didMatch) {
 							context.getWorkspaceState().update(ConfigurationIndexKey, idx);
 							setCurrent(getCurrent());
 						} else {


### PR DESCRIPTION
Related to my previous pull request #542 

Inspired by @Gama11's suggestion, this feature adds automatic configuration selection based on one or more globbing patterns specified in the haxe.configurations section in settings.json.

A new field "files" can be specified along with the existing "label" and "args" fields. When the active editor changes, the configurations are checked to see if a pattern in the files array match the current file. The first configuration that matches is selected, meaning a catch all case can be specified as the last configuration. See the example below.

```
"haxe.configurations": [
      {
          "label": "A",
          "args": ["--run A.hx"],
          "files":  ["A.hx", "C.hx"]
      },
      {
          "label": "B",
          "args": ["--run B.hx"],
          "files":  ["B.hx"]
      },
      {
          "label": "any",
          "args": ["build.hxml"],
          "files":  ["**/*.hx"]
      }
}
```