### PR TITLE
Show Output Channel command

### DIFF
--- a/package.json
+++ b/package.json
@@ -997,6 +997,11 @@
 				"title": "Go to",
 				"command": "haxe.cache.gotoNode",
 				"category": "Haxe"
+			},
+			{
+				"title": "Show Output Channel",
+				"command": "haxe.showOutputChannel",
+				"category": "Haxe"
 			}
 		],
 		"languages": [

--- a/src/vshaxe/HaxeCommand.hx
+++ b/src/vshaxe/HaxeCommand.hx
@@ -32,6 +32,7 @@ enum abstract HaxeCommand(String) to String {
 	final Cache_CopyNodeValue = command("cache.copyNodeValue");
 	final Cache_ReloadNode = command("cache.reloadNode");
 	final Cache_GotoNode = command("cache.gotoNode");
+	final ShowOutputChannel = command("showOutputChannel");
 
 	inline static function command(name:String):String {
 		return "haxe." + name;

--- a/src/vshaxe/commands/Commands.hx
+++ b/src/vshaxe/commands/Commands.hx
@@ -20,6 +20,7 @@ class Commands {
 		context.registerHaxeCommand(ToggleCodeLens, toggleCodeLens);
 		context.registerHaxeCommand(DebugSelectedConfiguration, debugSelectedConfiguration);
 		context.registerHaxeCommand(CodeAction_HighlightInsertion, highlightInsertion);
+		context.registerHaxeCommand(ShowOutputChannel, showOutputChannel);
 
 		#if debug
 		context.registerHaxeCommand(ClearMementos, clearMementos);
@@ -95,5 +96,10 @@ class Commands {
 
 	function highlightInsertion(uri:String, range:Range) {
 		window.showTextDocument(Uri.parse(uri)).then(editor -> editor.revealRange(range));
+	}
+
+	function showOutputChannel():Void {
+		final serverClient = server.client ?? return;
+		serverClient.outputChannel.show();
 	}
 }


### PR DESCRIPTION
Useful for debugging, can be hotkeyed.
Maybe someone knows how to call it at the start of debug vshaxe session?
UPD: there is task
```json
{
	"label": "ShowOutputChannel on open",
	"hide": true,
	"command": "${command:haxe.showOutputChannel}",
	"runOptions": {
		"runOn": "folderOpen"
	}
}
```