### PR TITLE
Update flag usage in template hxml

### DIFF
--- a/scaffold/project/build.hxml
+++ b/scaffold/project/build.hxml
@@ -1,4 +1,4 @@
--cp src
+-p src
 -D analyzer-optimize
--main Main
+--main Main
 --interp


### PR DESCRIPTION
`-p` is the new version of the flag that should be preferred over `-cp`. For long flag names like `--main`, two dashes should be used. These are also the versions displayed in `haxe --help` and in hxml completion, which makes things slightly more consistent and less confusing.