### PR TITLE
Insert Snippet command

### DIFF
--- a/src/vshaxe/HaxeCommand.hx
+++ b/src/vshaxe/HaxeCommand.hx
@@ -17,6 +17,8 @@ enum abstract HaxeCommand(String) to String {
 	final ShowReferences = command("showReferences");
 	final ClearMementos = command("clearMementos");
 	final CodeAction_HighlightInsertion = command("codeAction.highlightInsertion");
+	final CodeAction_InsertSnippet = command("codeAction.insertSnippet");
+	final CodeAction_SelectRanges = command("codeAction.selectRanges");
 	final Methods_SwitchToQueue = command("methods.switchToQueue");
 	final Methods_SwitchToTimers = command("methods.switchToTimers");
 	final Methods_Copy = command("methods.copy");

--- a/src/vshaxe/commands/Commands.hx
+++ b/src/vshaxe/commands/Commands.hx
@@ -105,7 +105,7 @@ class Commands {
 		window.showTextDocument(Uri.parse(uri)).then(editor -> {
 			final firstLine = editor.document.lineAt(range.start.line);
 			final indentNum = lineIndentationCount(firstLine.text);
-			snippet = prepateSnippetIndentation(snippet, indentNum);
+			snippet = prepareSnippetIndentation(snippet, indentNum);
 			final range = new Range(range.start, range.end);
 			final str = new SnippetString(snippet);
 			editor.insertSnippet(str, range);
@@ -142,7 +142,7 @@ class Commands {
 			}
 			final firstLine = editor.document.lineAt(fullRange.start.line);
 			final indentNum = lineIndentationCount(firstLine.text);
-			snippet = prepateSnippetIndentation(snippet, indentNum);
+			snippet = prepareSnippetIndentation(snippet, indentNum);
 			final str = new SnippetString(snippet);
 			editor.insertSnippet(str, fullRange);
 		});
@@ -158,7 +158,7 @@ class Commands {
 		return spaces;
 	}
 
-	function prepateSnippetIndentation(snippet:String, indent:Int):String {
+	function prepareSnippetIndentation(snippet:String, indent:Int):String {
 		// snippet adds first line indentation to all next lines,
 		// so we need to remove next line indentations
 		final startIndentCount = indent;

--- a/src/vshaxe/server/LanguageServer.hx
+++ b/src/vshaxe/server/LanguageServer.hx
@@ -160,7 +160,10 @@ class LanguageServer {
 				haxelibConfig: {
 					executable: haxeInstallation.haxelib.configuration.executable
 				},
-				sendMethodResults: true
+				sendMethodResults: true,
+				experimentalClientCapabilities: {
+					supportedCommands: [CodeAction_InsertSnippet]
+				}
 			},
 			revealOutputChannelOn: Never,
 			workspaceFolder: folder


### PR DESCRIPTION
Clients can pass `experimentalClientCapabilities: {supportedCommands: "codeAction.insertSnippet"}}` in `initializationOptions` to get snippets instead of codeaction edits in some places.

See https://github.com/vshaxe/haxe-language-server/pull/99

`selectRanges` function is unused, so can be removed, but it works and can be used for array of edits, when we do not want to merge them in one snippet on server. Maybe can be keeped?