### PR TITLE
Save on FixAll

### DIFF
--- a/src/vshaxe/commands/Commands.hx
+++ b/src/vshaxe/commands/Commands.hx
@@ -131,6 +131,8 @@ class Commands {
 						}
 					}
 				}
+			}).then(canBeApplied -> {
+				document.save();
 			});
 		});
 	}


### PR DESCRIPTION
Found that this action does not save changes on file save when extension is installed, in comparison to debug window behavior, so diagnostics is not updated without another ctrl-s.
It can be little better to read `"source.fixAll": true` for this, but i cannot get value if `"editor.codeActionsOnSave"` is inside of `"[haxe]"` object in `settings.json`. Still, this seems like a harmless improvement.