### PR TITLE
Build task rework - Pretty errors support

### DIFF
--- a/haxe_libraries/hxnodejs.hxml
+++ b/haxe_libraries/hxnodejs.hxml
@@ -1,5 +1,5 @@
-# @install: lix --silent download "haxelib:/hxnodejs#12.1.0" into hxnodejs/12.1.0/haxelib
--cp ${HAXE_LIBCACHE}/hxnodejs/12.1.0/haxelib/src
+# @install: lix --silent download "gh://github.com/HaxeFoundation/hxnodejs#14bc6880d4557d70e567a21ed50dff5587083f21" into hxnodejs/12.1.0/github/14bc6880d4557d70e567a21ed50dff5587083f21
+-cp ${HAXE_LIBCACHE}/hxnodejs/12.1.0/github/14bc6880d4557d70e567a21ed50dff5587083f21/src
 -D hxnodejs=12.1.0
 --macro allowPackage('sys')
 # should behave like other target defines and not be defined in macro context

--- a/package.json
+++ b/package.json
@@ -1202,7 +1202,7 @@
 			},
 			{
 				"name": "haxe-trace",
-				"regexp": "^(.+):(\\d+): (.*)$",
+				"regexp": "^([^\\s].+):(\\d+): (.*)$",
 				"file": 1,
 				"line": 2,
 				"message": 3

--- a/src/vshaxe/helper/SemVer.hx
+++ b/src/vshaxe/helper/SemVer.hx
@@ -93,7 +93,7 @@ abstract SemVer(String) to String {
 	@:to function get_data():SemVerData {
 		if (!cache.exists(this))
 			cache[this] = getData();
-		return cache[this];
+		@:nullSafety(Off) return cache[this];
 	}
 
 	@:from static function fromData(data:SemVerData)

--- a/src/vshaxe/helper/SemVer.hx
+++ b/src/vshaxe/helper/SemVer.hx
@@ -1,0 +1,144 @@
+package vshaxe.helper;
+
+import haxe.ds.Option;
+
+using Std;
+
+enum Preview {
+	ALPHA;
+	BETA;
+	RC;
+}
+
+abstract SemVer(String) to String {
+
+	public var major(get, never):Int;
+	public var minor(get, never):Int;
+	public var patch(get, never):Int;
+	public var preview(get, never):Null<Preview>;
+	public var previewNum(get, never):Null<Int>;
+	public var data(get, never):SemVerData;
+	public var valid(get, never):Bool;
+
+	inline function new(s) this = s;
+
+	static public function compare(a:SemVer, b:SemVer) {
+		function toArray(data:SemVerData)
+			return [
+				data.major,
+				data.minor,
+				data.patch,
+				if (data.preview == null) 100 else data.preview.getIndex(),
+				if (data.previewNum == null) -1 else data.previewNum
+			];
+
+		var a = toArray(a.data),
+			b = toArray(b.data);
+
+		for (i in 0...a.length)
+			switch Reflect.compare(a[i], b[i]) {
+				case 0:
+				case v: return v;
+			}
+
+		return 0;
+	}
+
+	inline function get_major()
+		return data.major;
+
+	inline function get_minor()
+		return data.minor;
+
+	inline function get_patch()
+		return data.patch;
+
+	inline function get_preview()
+		return data.preview;
+
+	inline function get_previewNum()
+		return data.previewNum;
+
+	inline function get_valid()
+		return isValid(this);
+
+	@:op(a > b) static inline function gt(a:SemVer, b:SemVer)
+		return compare(a, b) == 1;
+
+	@:op(a >= b) static inline function gteq(a:SemVer, b:SemVer)
+		return compare(a, b) != -1;
+
+	@:op(a < b) static inline function lt(a:SemVer, b:SemVer)
+		return compare(a, b) == -1;
+
+	@:op(a <= b) static inline function lteq(a:SemVer, b:SemVer)
+		return compare(a, b) != 1;
+
+	@:op(a == b) static inline function eq(a:SemVer, b:SemVer)
+		return compare(a, b) == 0;
+
+	@:op(a != b) static inline function neq(a:SemVer, b:SemVer)
+		return compare(a, b) != 0;
+
+	static var FORMAT = ~/^(\d|[1-9]\d*)\.(\d|[1-9]\d*)\.(\d|[1-9]\d*)(-(alpha|beta|rc)(\.(\d|[1-9]\d*))?)?(?:\+.*)?$/;
+
+	static var cache = new Map();
+
+	@:to function get_data():SemVerData {
+		if (!cache.exists(this))
+			cache[this] = getData();
+		return cache[this];
+	}
+
+	@:from static function fromData(data:SemVerData)
+		return
+			new SemVer(
+				data.major + '.' + data.minor + '.' + data.patch +
+					if (data.preview == null) ''
+					else '-' + data.preview.getName().toLowerCase() +
+						if (data.previewNum == null) '';
+						else '.' + data.previewNum
+			);
+
+	function getData():SemVerData
+		return
+			if (valid) {//RAPTORS: This query will already cause the matching.
+				major: FORMAT.matched(1).parseInt(),
+				minor: FORMAT.matched(2).parseInt(),
+				patch: FORMAT.matched(3).parseInt(),
+				preview:
+					switch FORMAT.matched(5) {
+						case 'alpha': ALPHA;
+						case 'beta': BETA;
+						case 'rc': RC;
+						case v if (v == null): null;
+						case v: throw 'unrecognized preview tag $v';
+					},
+				previewNum:
+					switch FORMAT.matched(7) {
+						case null: null;
+						case v: v.parseInt();
+					}
+			}
+			else
+				throw '$this is not a valid version string';//TODO: include some URL for reference
+
+	static public function isValid(s:String)
+		return Std.is(s, String) && FORMAT.match(s.toLowerCase());
+
+	static public function ofString(s:String) {
+		var ret = new SemVer(s);
+		ret.getData();
+		return ret;
+	}
+
+	static public var DEFAULT(default, null) = new SemVer('0.0.0');
+}
+
+typedef SemVerData =  {
+	major:Int,
+	minor:Int,
+	patch:Int,
+	preview:Null<Preview>,
+	previewNum:Null<Int>,
+}

--- a/src/vshaxe/helper/SemVer.hx
+++ b/src/vshaxe/helper/SemVer.hx
@@ -11,7 +11,6 @@ enum Preview {
 }
 
 abstract SemVer(String) to String {
-
 	public var major(get, never):Int;
 	public var minor(get, never):Int;
 	public var patch(get, never):Int;
@@ -20,7 +19,8 @@ abstract SemVer(String) to String {
 	public var data(get, never):SemVerData;
 	public var valid(get, never):Bool;
 
-	inline function new(s) this = s;
+	inline function new(s)
+		this = s;
 
 	static public function compare(a:SemVer, b:SemVer) {
 		function toArray(data:SemVerData)
@@ -28,17 +28,23 @@ abstract SemVer(String) to String {
 				data.major,
 				data.minor,
 				data.patch,
-				if (data.preview == null) 100 else data.preview.getIndex(),
-				if (data.previewNum == null) -1 else data.previewNum
+				if (data.preview == null)
+					100
+				else
+					data.preview.getIndex(),
+				if (data.previewNum == null)
+					-1
+				else
+					data.previewNum
 			];
 
-		var a = toArray(a.data),
-			b = toArray(b.data);
+		var a = toArray(a.data), b = toArray(b.data);
 
 		for (i in 0...a.length)
 			switch Reflect.compare(a[i], b[i]) {
 				case 0:
-				case v: return v;
+				case v:
+					return v;
 			}
 
 		return 0;
@@ -91,37 +97,30 @@ abstract SemVer(String) to String {
 	}
 
 	@:from static function fromData(data:SemVerData)
-		return
-			new SemVer(
-				data.major + '.' + data.minor + '.' + data.patch +
-					if (data.preview == null) ''
-					else '-' + data.preview.getName().toLowerCase() +
-						if (data.previewNum == null) '';
-						else '.' + data.previewNum
-			);
+		return new SemVer(data.major
+			+ '.'
+			+ data.minor
+			+ '.'
+			+ data.patch
+			+ if (data.preview == null) '' else '-' + data.preview.getName().toLowerCase() + if (data.previewNum == null) ''; else '.' + data.previewNum);
 
 	function getData():SemVerData
-		return
-			if (valid) {//RAPTORS: This query will already cause the matching.
-				major: FORMAT.matched(1).parseInt(),
-				minor: FORMAT.matched(2).parseInt(),
-				patch: FORMAT.matched(3).parseInt(),
-				preview:
-					switch FORMAT.matched(5) {
-						case 'alpha': ALPHA;
-						case 'beta': BETA;
-						case 'rc': RC;
-						case v if (v == null): null;
-						case v: throw 'unrecognized preview tag $v';
-					},
-				previewNum:
-					switch FORMAT.matched(7) {
-						case null: null;
-						case v: v.parseInt();
-					}
+		return if (valid) { // RAPTORS: This query will already cause the matching.
+			major: FORMAT.matched(1).parseInt(),
+			minor: FORMAT.matched(2).parseInt(),
+			patch: FORMAT.matched(3).parseInt(),
+			preview: switch FORMAT.matched(5) {
+				case 'alpha': ALPHA;
+				case 'beta': BETA;
+				case 'rc': RC;
+				case v if (v == null): null;
+				case v: throw 'unrecognized preview tag $v';
+			},
+			previewNum: switch FORMAT.matched(7) {
+				case null: null;
+				case v: v.parseInt();
 			}
-			else
-				throw '$this is not a valid version string';//TODO: include some URL for reference
+		} else throw '$this is not a valid version string'; // TODO: include some URL for reference
 
 	static public function isValid(s:String)
 		return Std.is(s, String) && FORMAT.match(s.toLowerCase());
@@ -135,7 +134,7 @@ abstract SemVer(String) to String {
 	static public var DEFAULT(default, null) = new SemVer('0.0.0');
 }
 
-typedef SemVerData =  {
+typedef SemVerData = {
 	major:Int,
 	minor:Int,
 	patch:Int,

--- a/src/vshaxe/server/LanguageServer.hx
+++ b/src/vshaxe/server/LanguageServer.hx
@@ -150,6 +150,7 @@ class LanguageServer {
 				{language: "hxml", scheme: "file"},
 				{language: "hxml", scheme: "untitled"}
 			],
+			diagnosticCollectionName: "haxe",
 			synchronize: {
 				configurationSection: "haxe",
 				fileEvents: resFileWatcher.concat([hxFileWatcher])

--- a/src/vshaxe/tasks/HaxeTaskProvider.hx
+++ b/src/vshaxe/tasks/HaxeTaskProvider.hx
@@ -29,7 +29,7 @@ class HaxeTaskProvider {
 	}
 
 	public function resolveTask(task:Task, ?token:CancellationToken):ProviderResult<Task> {
-		return task;
+		return taskConfiguration.createTask(task.definition, "active configuration", displayArguments.arguments);
 	}
 }
 

--- a/src/vshaxe/tasks/HaxeTaskProvider.hx
+++ b/src/vshaxe/tasks/HaxeTaskProvider.hx
@@ -29,7 +29,7 @@ class HaxeTaskProvider {
 	}
 
 	public function resolveTask(task:Task, ?token:CancellationToken):ProviderResult<Task> {
-		return taskConfiguration.createTask(task.definition, "active configuration", displayArguments.arguments);
+		return taskConfiguration.createTask(task.definition, "active configuration", displayArguments.arguments ?? []);
 	}
 }
 

--- a/src/vshaxe/tasks/HxmlTaskProvider.hx
+++ b/src/vshaxe/tasks/HxmlTaskProvider.hx
@@ -13,7 +13,7 @@ class HxmlTaskProvider {
 	public function provideTasks(?token:CancellationToken):ProviderResult<Array<Task>> {
 		return [
 			for (file in hxmlDiscovery.files) {
-				final definition:HaxeTaskDefinition = {
+				final definition:HxmlTaskDefinition = {
 					type: "hxml",
 					file: file
 				};
@@ -23,8 +23,10 @@ class HxmlTaskProvider {
 	}
 
 	public function resolveTask(task:Task, ?token:CancellationToken):ProviderResult<Task> {
-		return task;
+		final definition:HxmlTaskDefinition = cast task.definition;
+		final file = definition.file;
+		return taskConfiguration.createTask(definition, file, [file]);
 	}
 }
 
-private typedef HaxeTaskDefinition = TaskDefinition & {file:String};
+typedef HxmlTaskDefinition = TaskDefinition & {file:String};

--- a/src/vshaxe/tasks/TaskConfiguration.hx
+++ b/src/vshaxe/tasks/TaskConfiguration.hx
@@ -147,11 +147,13 @@ class TaskConfiguration {
 			}
 
 			function postProcess(diagnostic:Diagnostic) {
-				if (diagnostic.relatedInformation.or([]).length == 0) return;
+				if (diagnostic.relatedInformation.or([]).length == 0)
+					return;
 
 				var message = diagnostic.message;
 				for (rel in diagnostic.relatedInformation.or([])) {
-					if (!rel.location.range.isEqual(diagnostic.range)) return;
+					if (!rel.location.range.isEqual(diagnostic.range))
+						return;
 					message += "\n" + rel.message;
 				}
 
@@ -168,7 +170,8 @@ class TaskConfiguration {
 					final uri = Uri.file(file);
 
 					if (isEmpty(problemMatcher.matched(1))) {
-						if (diagnostic != null) postProcess(diagnostic);
+						if (diagnostic != null)
+							postProcess(diagnostic);
 
 						diagnostic = new Diagnostic(createRange(), problemMatcher.matched(9), switch problemMatcher.matched(7) {
 							case null | "": Error;
@@ -200,7 +203,8 @@ class TaskConfiguration {
 				}
 			}
 
-			if (diagnostic != null) postProcess(diagnostic);
+			if (diagnostic != null)
+				postProcess(diagnostic);
 			server.client?.diagnostics?.set([for (file => diag in diagnostics) [(Uri.file(file) : Any), (diag : Any)]]);
 
 			// TODO: add some settings to _not_ delete the file?

--- a/src/vshaxe/tasks/TaskConfiguration.hx
+++ b/src/vshaxe/tasks/TaskConfiguration.hx
@@ -11,6 +11,8 @@ import vshaxe.helper.SemVer;
 import vshaxe.server.LanguageServer;
 import vshaxe.tasks.HxmlTaskProvider.HxmlTaskDefinition;
 
+using Safety;
+
 private typedef WriteableApi = {
 	enableCompilationServer:Bool,
 	taskPresentation:vshaxe.TaskPresentationOptions
@@ -54,7 +56,7 @@ class TaskConfiguration {
 	}
 
 	function update() {
-		haxeVersion = try SemVer.ofString(haxeInstallation.haxe.configuration.version) catch (_) SemVer.DEFAULT;
+		haxeVersion = try SemVer.ofString(haxeInstallation.haxe.configuration.version.or("")) catch (_) SemVer.DEFAULT;
 
 		enableCompilationServer = workspace.getConfiguration("haxe").get("enableCompilationServer", true);
 		final presentation:{
@@ -129,11 +131,11 @@ class TaskConfiguration {
 				return s == null || s == "";
 
 			function createRange() {
-				var line = Std.parseInt(problemMatcher.matched(3));
-				var lineEnd = isEmpty(problemMatcher.matched(4)) ? line : Std.parseInt(problemMatcher.matched(4));
+				var line = Std.parseInt(problemMatcher.matched(3)).or(1);
+				var lineEnd = Std.parseInt(problemMatcher.matched(4)).or(line);
 
-				var colEnd = Std.parseInt(problemMatcher.matched(6));
-				var col = isEmpty(problemMatcher.matched(5)) ? colEnd : Std.parseInt(problemMatcher.matched(5));
+				var colEnd = Std.parseInt(problemMatcher.matched(6)).or(1);
+				var col = Std.parseInt(problemMatcher.matched(5)).or(colEnd);
 
 				return new Range(new Position(line - 1, col - 1), new Position(lineEnd - 1, colEnd - 1));
 			}
@@ -149,6 +151,9 @@ class TaskConfiguration {
 
 			for (line in logs.split("\n")) {
 				if (problemMatcher.match(line)) {
+					final file = PathHelper.absolutize(problemMatcher.matched(2).or(""), workspace.rootPath.or(""));
+					final uri = Uri.file(file);
+
 					if (isEmpty(problemMatcher.matched(1))) {
 						diagnostic = new Diagnostic(createRange(), problemMatcher.matched(9), switch problemMatcher.matched(7) {
 							case null | "": Error;
@@ -163,17 +168,11 @@ class TaskConfiguration {
 							diagnostic.tags.push(Deprecated);
 						}
 
-						final file = PathHelper.absolutize(problemMatcher.matched(2), workspace.rootPath);
-						final uri = Uri.file(file);
-
 						if (!diagnostics.exists(file))
 							diagnostics.set(file, [diagnostic]);
 						else
-							diagnostics.get(file).push(diagnostic);
+							@:nullSafety(Off) diagnostics.get(file).push(diagnostic);
 					} else if (diagnostic != null) {
-						final file = PathHelper.absolutize(problemMatcher.matched(2), workspace.rootPath);
-						final uri = Uri.file(file);
-
 						// Add related info
 						var rel = new DiagnosticRelatedInformation(new Location(uri, createRange()),
 							convertIndentation(problemMatcher.matched(1)) + problemMatcher.matched(9));
@@ -186,7 +185,7 @@ class TaskConfiguration {
 				}
 			}
 
-			server.client.diagnostics.set([for (file => diag in diagnostics) [(Uri.file(file) : Any), (diag : Any)]]);
+			server.client?.diagnostics?.set([for (file => diag in diagnostics) [(Uri.file(file) : Any), (diag : Any)]]);
 
 			// TODO: add some settings to _not_ delete the file?
 			Fs.unlink(path, (err) -> if (err != null) outputChannel.appendLine('Error while removing log file: ' + err.message));

--- a/src/vshaxe/tasks/TaskConfiguration.hx
+++ b/src/vshaxe/tasks/TaskConfiguration.hx
@@ -103,7 +103,7 @@ class TaskConfiguration {
 			final defineNamespace = haxeVersion == haxe_4_3_0 ? "message-" : "message.";
 
 			args = args.concat([
-				"-D", '${defineNamespace}log-file=$path',
+				"-D",  '${defineNamespace}log-file=$path',
 				"-D", '${defineNamespace}log-format=indent'
 			]);
 		}


### PR DESCRIPTION
~~Needs https://github.com/vshaxe/haxe-language-server/pull/103
https://github.com/vshaxe/haxe-language-server/pull/102 would be nice too as it's about pretty errors.~~ both have been merged

Rework our tasks so that haxe 4.3.x can provide better "problems" from compiler output:

![image](https://user-images.githubusercontent.com/6101998/236625991-7d291620-fa7e-4b46-9075-f44d2c5fb040.png)

This is bypassing vscode's many limitations regarding problem matchers by creating diagnostics and feeding them into Haxe LSP's diagnostics collection. This collection is also a bit stabilized, building should clear previous diagnostics and there shouldn't be double errors in problems view again.

This also fixes the recent issues of vshaxe not being able to handle Haxe 4.3's pretty errors.

This is not 100% without issues, though. Some edge cases I could not handle properly because of vscode's internal workings:
 * If you have `problemMatchers` defined for your haxe tasks in `tasks.json`, this can interfere with the feature. You'll need to remove that field, and possibly reload vscode because of its cache
 * Switching Haxe versions from older than 4.3.0 to newer (and vice versa) while using vscode can also break error message extraction until you reload vscode

Note that real diagnostics are not affected by these issues.