### PR TITLE
[tasks] use a fake problem matcher on haxe >= 4.3 to trigger default vscode behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -1211,6 +1211,10 @@
 				"file": 1,
 				"line": 2,
 				"message": 3
+			},
+			{
+				"name": "haxe-fake",
+				"regexp": "^## Fake problem matcher ##$"
 			}
 		],
 		"problemMatchers": [

--- a/src/vshaxe/tasks/TaskConfiguration.hx
+++ b/src/vshaxe/tasks/TaskConfiguration.hx
@@ -111,8 +111,11 @@ class TaskConfiguration {
 			]);
 		}
 
+		// We're not using problem matchers there but vscode needs some to
+		// know that the task is running etc.
+		final problemMatchers = haxeVersion < haxe_4_3_0 ? problemMatchers : ["haxe-fake"];
+
 		final execution = new ProcessExecution(executable, args, {env: haxeInstallation.env});
-		final problemMatchers = haxeVersion < haxe_4_3_0 ? problemMatchers : [];
 		final task = new Task(definition, TaskScope.Workspace, name, definition.type, execution, problemMatchers);
 		task.group = TaskGroup.Build;
 		task.presentationOptions = taskPresentation;


### PR DESCRIPTION
Closes #614 

This definitely is a hack.. but vscode skips a lot of behavior, including displaying "Building..." during the task, if the task doesn't use the built-in (and limited) problem matcher.