### PR TITLE
EvalDebugger: if there is no HXML, and the currently active editor contains a .hx file, automatically generate args to run it

### DIFF
--- a/src/vshaxe/EvalDebugger.hx
+++ b/src/vshaxe/EvalDebugger.hx
@@ -1,5 +1,6 @@
 package vshaxe;
 
+import haxe.io.Path;
 import vshaxe.HaxeExecutableConfiguration;
 import vshaxe.display.DisplayArguments;
 
@@ -37,11 +38,23 @@ class EvalDebugger {
 		}
 		if (config.args == null) {
 			if (displayArguments.arguments == null) {
-				window.showErrorMessage('No Haxe configuration exists. '
-					+ 'Please create a HXML file, use the "haxe.configurations" setting or set `args` in the launch configuration.');
-				return js.Lib.undefined;
+				if (window.activeTextEditor != null) {
+					var document = window.activeTextEditor.document;
+					var baseFileName = Path.withoutDirectory(document.fileName);
+					if (baseFileName.endsWith(".hx")) {
+						var dirPath = Path.directory(document.fileName);
+						var mainClassName = baseFileName.substr(0, baseFileName.length - 3);
+						config.args = ["--interp", "-cp", dirPath, "--main", mainClassName];
+					}
+				}
+				if (config.args == null) {
+					window.showErrorMessage('No Haxe configuration exists. '
+						+ 'Please create a HXML file, use the "haxe.configurations" setting or set `args` in the launch configuration.');
+					return js.Lib.undefined;
+				}
+			} else {
+				config.args = displayArguments.arguments;
 			}
-			config.args = displayArguments.arguments;
 		}
 		config.haxeExecutable = haxeExecutable.configuration;
 		config.mergeScopes = workspace.getConfiguration("haxe.debug").get("mergeScopes", true);


### PR DESCRIPTION
One less thing that needs to be manually configured before being able to launch the eval debugger.

It still requires a workspace folder to be open, same as before. It just doesn't require a .hxml file in the workspace before you can try debugging the currently active .hx file.

It would be fun to take things a step further and allow the eval debugger to work with any random .hx file that's open in VSCode, even if there is no workspace folder currently open. I see that there's a comment about that already:

> // TODO: look into this - we could support _some_ nice functionality (e.g. std lib completion or --interp task)