### PR TITLE
Update SemVer for -preview

### DIFF
--- a/src/vshaxe/helper/SemVer.hx
+++ b/src/vshaxe/helper/SemVer.hx
@@ -7,6 +7,7 @@ using Std;
 enum Preview {
 	ALPHA;
 	BETA;
+	PREVIEW;
 	RC;
 }
 
@@ -80,7 +81,7 @@ abstract SemVer(String) to String {
 	@:op(a != b) static inline function neq(a:SemVer, b:SemVer)
 		return compare(a, b) != 0;
 
-	static var FORMAT = ~/^(\d|[1-9]\d*)\.(\d|[1-9]\d*)\.(\d|[1-9]\d*)(-(alpha|beta|rc)(\.(\d|[1-9]\d*))?)?(?:\+.*)?$/;
+	static var FORMAT = ~/^(\d|[1-9]\d*)\.(\d|[1-9]\d*)\.(\d|[1-9]\d*)(-(alpha|beta|preview|rc)(\.(\d|[1-9]\d*))?)?(?:\+.*)?$/;
 
 	static var cache = new Map();
 
@@ -106,6 +107,7 @@ abstract SemVer(String) to String {
 			preview: switch FORMAT.matched(5) {
 				case 'alpha': ALPHA;
 				case 'beta': BETA;
+				case 'preview': PREVIEW;
 				case 'rc': RC;
 				case v if (v == null): null;
 				case v: throw 'unrecognized preview tag $v';


### PR DESCRIPTION
5.0 preview isn't recognized by vshaxe, which cause error message parsing failed to generate the right location.

Ref https://github.com/HaxeFoundation/haxelib/commit/20199d4e6c1eec17286efdc52067ad6ff94bb3d7